### PR TITLE
Align footer to bottom and animate header

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -4,12 +4,41 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 header {
   background-color: #004c99;
   color: white;
   padding: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+header::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.2) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.2) 1px, transparent 1px);
+  background-size: 20px 20px;
+  animation: moveGrid 10s linear infinite;
+}
+
+@keyframes moveGrid {
+  from {
+    transform: translate(0, 0);
+  }
+  to {
+    transform: translate(20px, 20px);
+  }
 }
 
 header a {
@@ -19,6 +48,7 @@ header a {
 
 main {
   padding: 1rem;
+  flex: 1;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- keep footer pinned to bottom using flexbox layout
- add animated grid effect to header background

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a46f5b07083228da3a09510102293