### PR TITLE
Refine fonts and link colors

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,12 +1,23 @@
 body {
   background-color: #f0f8ff;
   color: #000000;
-  font-family: Arial, sans-serif;
+  font-family: "Helvetica", sans-serif;
+  font-size: 12px;
   margin: 0;
   padding: 0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+
+a {
+  color: #001f5c;
+  text-decoration: none;
+}
+
+a:visited {
+  color: #000b3d;
+  text-decoration: none;
 }
 
 header {
@@ -44,6 +55,12 @@ header::after {
 header a {
   color: white;
   text-decoration: none;
+}
+
+h1 {
+  font-family: "Rockwell", "Arial Black", serif;
+  font-size: 19px;
+  margin: 0;
 }
 
 main {


### PR DESCRIPTION
## Summary
- change body to Helvetica and 12px
- add slab serif header at 19px
- update link color and remove underlines

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c5e22508322abc61818c69a2f9a