### PR TITLE
Add gradient background to header

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -10,7 +10,9 @@ body {
 }
 
 header {
-  background-color: #004c99;
+  background: linear-gradient(135deg, #cfe9ff, #004c99);
+  background-size: 200% 200%;
+  animation: shimmer 8s ease-in-out infinite;
   color: white;
   padding: 1rem;
   position: relative;
@@ -20,10 +22,10 @@ header {
 header::after {
   content: "";
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  top: -20px;
+  left: -20px;
+  width: calc(100% + 40px);
+  height: calc(100% + 40px);
   pointer-events: none;
   background-image:
     linear-gradient(rgba(255,255,255,0.2) 1px, transparent 1px),
@@ -38,6 +40,18 @@ header::after {
   }
   to {
     transform: translate(20px, 20px);
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }
 


### PR DESCRIPTION
## Summary
- enhance header with a shimmering gradient
- let animated grid extend past edges to hide borders

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4c9ee2088322881957925d2fd3f5