### PR TITLE
Adjust layout for visible title

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
+  <h1 class="page-title">{{ site.title }}</h1>
   <header>
-    <h1><a href="/">{{ site.title | default: "Home" }}</a></h1>
   </header>
   <main>
     {{ content }}

--- a/assets/style.css
+++ b/assets/style.css
@@ -8,6 +8,19 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+header,
+main,
+footer {
+  width: 100%;
+}
+
+.page-title {
+  color: #F8FAFC;
+  margin: 1rem 0;
 }
 
 a {


### PR DESCRIPTION
## Summary
- move page title outside animated header
- center layout with flexbox
- style page title color

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_685a685853848322979308066509b6ff